### PR TITLE
add a logout button

### DIFF
--- a/src/AuthLinker.tsx
+++ b/src/AuthLinker.tsx
@@ -8,16 +8,6 @@ import type { OAuthSession } from '@atproto/oauth-client-browser';
 const AuthLinker: React.FC = () => {
   const [oauthSession, setOauthSession] = useState<OAuthSession | null>(null);
 
-  // this is just to make testing easier.
-  if (oauthSession?.did) {
-    const urlParams = new URLSearchParams(window.location.search);
-    const oauthRedoParam = urlParams.get('oauthRedo');
-    if (oauthRedoParam === 'true') {
-      oauthClient.revoke(oauthSession.did);
-      setOauthSession(null);
-    }
-  }
-
   useEffect(() => {
     const fetchSession = async () => {
       const initRes = await oauthClient.init();
@@ -30,8 +20,8 @@ const AuthLinker: React.FC = () => {
     <div>
       {oauthSession ? (
         <div>
-          <p>✅ authenticated on ATProto side as:</p>
-          <p>{oauthSession.sub}</p>
+          <p>✅ authenticated as: <b>{oauthSession.sub}</b></p>
+          <OAuthUI oauthSession={oauthSession} onSessionChange={setOauthSession} />
           <WalletConnector 
             isAuthenticated={!!oauthSession} 
             did={oauthSession?.sub} 
@@ -39,7 +29,7 @@ const AuthLinker: React.FC = () => {
           />
         </div>
       ) : (
-        <OAuthUI />
+        <OAuthUI oauthSession={oauthSession} onSessionChange={setOauthSession} />
       )}
     </div>
   );

--- a/src/oauthUI.tsx
+++ b/src/oauthUI.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
 import { oauthClient } from './oauth.ts';
+import type { OAuthSession } from '@atproto/oauth-client-browser';
 
-const OAuthUI: React.FC = () => {
+interface OAuthUIProps {
+  oauthSession?: OAuthSession | null;
+  onSessionChange?: (session: OAuthSession | null) => void;
+}
+
+const OAuthUI: React.FC<OAuthUIProps> = ({ oauthSession, onSessionChange }) => {
   const [handle, setHandle] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -16,17 +22,39 @@ const OAuthUI: React.FC = () => {
     }
   };
 
+  const handleLogout = async () => {
+    try {
+      if (oauthSession?.did) {
+        await oauthClient.revoke(oauthSession.did);
+        onSessionChange?.(null);
+      }
+    } catch (err) {
+      console.log('oauth logout error:', err);
+    }
+  };
+
   return (
     <div>
       <form onSubmit={handleSubmit}>
-        <input
-          type="text"
-          value={handle}
-          onChange={(e) => setHandle(e.target.value)}
-          placeholder="enter your Bluesky handle or DID"
-          style={{ fontSize: '18px', padding: '6px', width: '300px', textAlign: 'center', marginRight: '8px' }}
-        />
-        <button type="submit">Login</button>
+        {!oauthSession && (
+          <input
+            type="text"
+            value={handle}
+            onChange={(e) => setHandle(e.target.value)}
+            placeholder="enter your Bluesky handle or DID"
+            style={{ fontSize: '18px', padding: '6px', width: '300px', textAlign: 'center', marginRight: '8px' }}
+          />
+        )}
+        {!oauthSession && <button type="submit">Login</button>}
+        {oauthSession && (
+          <button 
+            type="button" 
+            onClick={handleLogout}
+            style={{ marginLeft: '8px' }}
+          >
+            Logout (on ATProto side)
+          </button>
+        )}
       </form>
     </div>
   );


### PR DESCRIPTION
by request, a logout button for the atproto side.

<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:524tuhdhh3m7li5gycdn6boe/app.bsky.feed.post/3lsqio6szus2r" data-bluesky-cid="bafyreig5aeebv5i3w7ub3p4xkluuwlzcxks4cdw2iveope5zvbnx6h733e" data-bluesky-embed-color-mode="system"><p lang="en">Just one little bug: When I entered the handle &quot;tree.fail&quot; I got &quot;Error: Failed to resolve identity..&quot;. When I typed in DID directly, everything was fine.

+ a logout button (from ATP) would be useful</p>&mdash; tree🌴 (<a href="https://bsky.app/profile/did:plc:524tuhdhh3m7li5gycdn6boe?ref_src=embed">@tree.fail</a>) <a href="https://bsky.app/profile/did:plc:524tuhdhh3m7li5gycdn6boe/post/3lsqio6szus2r?ref_src=embed">June 29, 2025 at 6:48 AM</a></blockquote>

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/81bb7507-d74e-499c-ad89-319547007d10" />
